### PR TITLE
feat(FOM-130): authenticate CI to AWS with GitHub OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,15 @@ jobs:
   Deploy-infra:
     name: 'Deploy Infra'
     needs: Pre-check
+    permissions:
+      id-token: write
+      contents: read
     uses: fomiller/gh-actions/.github/workflows/terragrunt.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
       infra-dir: infra/modules/aws
       doppler-project: aws-infra-shared-services
+      use-oidc: true
     secrets: inherit
 
   Github-Pages:


### PR DESCRIPTION
Switches the deploy job to GitHub OIDC. It assumes `github-actions-aws-infra-shared-services` in dev or prod, depending on the branch, instead of using static keys.

Note this repo also has live IAM access keys in a committed `env.list`. Those still need rotating and removing — separate change.

Draft until three things land, in this order: [aws-org#37](https://github.com/Fomiller/aws-org/pull/37) creates the role, [gh-actions#6](https://github.com/Fomiller/gh-actions/pull/6) adds the `use-oidc` input, and the `AWS_OIDC_ROLE_ARN` environment secret gets set. Merging before that breaks the next deploy.

Part of [FOM-130](https://linear.app/fomiller/issue/FOM-130/move-ci-to-github-oidc-federated-roles).