### PR TITLE
fix(FOM-134): drop the dead fomiller-cluster certificate

### DIFF
--- a/infra/modules/aws/acm/_inputs.tf
+++ b/infra/modules/aws/acm/_inputs.tf
@@ -1,4 +1,2 @@
 variable "route53_zone_name_fomillercloud_subdomain_public" { type = string }
 variable "route53_zone_id_fomillercloud_subdomain_public" { type = string }
-variable "route53_zone_name_fomillercloud_cluster_subdomain_public" { type = string }
-variable "route53_zone_id_fomillercloud_cluster_subdomain_public" { type = string }

--- a/infra/modules/aws/acm/acm.tf
+++ b/infra/modules/aws/acm/acm.tf
@@ -11,19 +11,6 @@ resource "aws_acm_certificate" "fomillercloud_subdomain_public_cert" {
   }
 }
 
-resource "aws_acm_certificate" "fomillercloud_cluster_subdomain_public_cert" {
-  domain_name       = var.route53_zone_name_fomillercloud_cluster_subdomain_public
-  validation_method = "DNS"
-
-  subject_alternative_names = [
-    "*.${var.route53_zone_name_fomillercloud_cluster_subdomain_public}"
-  ]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_route53_record" "fomillercloud_subdomain_cert_validation" {
   for_each = {
     for dvo in aws_acm_certificate.fomillercloud_subdomain_public_cert.domain_validation_options : dvo.domain_name => {
@@ -41,29 +28,7 @@ resource "aws_route53_record" "fomillercloud_subdomain_cert_validation" {
   zone_id         = var.route53_zone_id_fomillercloud_subdomain_public
 }
 
-resource "aws_route53_record" "fomillercloud_cluster_subdomain_cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.fomillercloud_cluster_subdomain_public_cert.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = var.route53_zone_id_fomillercloud_cluster_subdomain_public
-}
-
 resource "aws_acm_certificate_validation" "fomillercloud_subdomain_cert_validation" {
   certificate_arn         = aws_acm_certificate.fomillercloud_subdomain_public_cert.arn
   validation_record_fqdns = [for record in aws_route53_record.fomillercloud_subdomain_cert_validation : record.fqdn]
-}
-
-resource "aws_acm_certificate_validation" "fomillercloud_cluster_subdomain_cert_validation" {
-  certificate_arn         = aws_acm_certificate.fomillercloud_cluster_subdomain_public_cert.arn
-  validation_record_fqdns = [for record in aws_route53_record.fomillercloud_cluster_subdomain_cert_validation : record.fqdn]
 }

--- a/infra/modules/aws/acm/terragrunt.hcl
+++ b/infra/modules/aws/acm/terragrunt.hcl
@@ -9,14 +9,10 @@ dependency "route53" {
     mock_outputs = {
         route53_zone_name_fomillercloud_subdomain_public = "MOCK.aws.fomillercloud.com"
         route53_zone_id_fomillercloud_subdomain_public = "MOCK567689012"
-        route53_zone_name_fomillercloud_cluster_subdomain_public = "fomiller-cluster.MOCK.aws.fomillercloud.com"
-        route53_zone_id_fomillercloud_cluster_subdomain_public = "MOCK567689012"
     }
 }
 
 inputs = {
     route53_zone_name_fomillercloud_subdomain_public = dependency.route53.outputs.route53_zone_name_fomillercloud_subdomain_public
     route53_zone_id_fomillercloud_subdomain_public = dependency.route53.outputs.route53_zone_id_fomillercloud_subdomain_public
-    route53_zone_name_fomillercloud_cluster_subdomain_public = dependency.route53.outputs.route53_zone_name_fomillercloud_cluster_subdomain_public
-    route53_zone_id_fomillercloud_cluster_subdomain_public = dependency.route53.outputs.route53_zone_id_fomillercloud_cluster_subdomain_public
 }


### PR DESCRIPTION
The acm unit fails on every apply. Its certificate for `fomiller-cluster.dev.aws.fomillercloud.com` expired 2025-01-20:

- `Status: EXPIRED`, `RenewalEligibility: INELIGIBLE`
- `InUseBy` empty, nothing attached
- both domain validations show SUCCESS, so it isn't DNS. ACM won't renew a cert nothing uses.

`aws_acm_certificate_validation` waits for `ISSUED` and never gets it. The subdomain is dead, so this deletes rather than reissues ([FOM-134](https://linear.app/fomiller/issue/FOM-134/remove-the-dead-fomiller-cluster-subdomain-certificate)).

The unit manages two certificates. Only the cluster one goes — `fomillercloud_subdomain_public_cert` is live and untouched.

Plan is `0 to add, 0 to change, 3 to destroy`: the expired cert and its two validation records. The validation resource only ever existed in config.

The `fomillercloud_cluster_subdomain_public` hosted zone is still in the route53 unit. Removing it touches delegation records, so it's a separate job.