### PR TITLE
refactor(FOM-130): drop the static key from the org provider

### DIFF
--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -1,8 +1,54 @@
 # Authentication
-To authenticate with AWS locally use this command. It would be nice to update this  
-command to not have to use the `--preserve-env` flag, but right now this is the  
-current situation based on how [assume-role](https://github.com/Fomiller/assume-role) is configured.
+
+Local runs use AWS IAM Identity Center. CI uses GitHub OIDC. There are no
+static access keys on either path.
+
+## One-time setup
+
+`~/.aws/config`:
+
+```ini
+[sso-session fomiller]
+sso_start_url = https://d-9067a5b40d.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile org]
+sso_session = fomiller
+sso_account_id = 013683865476
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile dev]
+sso_session = fomiller
+sso_account_id = 695434033664
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile prod]
+sso_session = fomiller
+sso_account_id = 737133467188
+sso_role_name = AdministratorAccess
+region = us-east-1
+```
+
+## Every session
 
 ```bash
-doppler run --preserve-env="AWS_ASSUME_CONFIG_DIR" just login dev
+aws sso login --sso-session fomiller
 ```
+
+One browser round trip covers all three profiles.
+
+## Running terraform
+
+```bash
+export AWS_PROFILE=dev
+export AWS_ORG_PROFILE=org
+just plan route53
+```
+
+`AWS_PROFILE` is the account the stack deploys into. `AWS_ORG_PROFILE` is only
+needed for units that touch the org account — `route53` owns hosted zones
+there. Leave it unset in CI: the org provider then chains off the
+`github-actions` role the job already assumed.

--- a/infra/modules/aws/root.hcl
+++ b/infra/modules/aws/root.hcl
@@ -2,6 +2,23 @@ locals {
     namespace = "fomiller"
     app_prefix = "aws-infra"
     project_name = "aws-infra-shared-services"
+
+    # A few units manage resources in the org account. Locally that is a second
+    # SSO profile. CI has no profiles, so there the org provider chains off the
+    # github-actions role the job already assumed. Either way, no static key.
+    org_profile = get_env("AWS_ORG_PROFILE", "")
+
+    org_auth_local = <<-EOT
+      profile = "${get_env("AWS_ORG_PROFILE", "")}"
+    EOT
+
+    org_auth_ci = <<-EOT
+      assume_role {
+          role_arn = "arn:aws:iam::${get_env("TF_VAR_org_account_id", "")}:role/github-actions"
+        }
+    EOT
+
+    org_auth = local.org_profile != "" ? local.org_auth_local : local.org_auth_ci
 }
 
 generate provider {
@@ -19,15 +36,9 @@ provider "aws" {
   }
 }
 
-# Chains off whatever the caller already is — the github-actions role in CI,
-# an SSO session locally. No static key.
 provider "aws" {
   alias = "org"
-  assume_role {
-      role_arn = format("arn:aws:iam::%s:role/github-actions",
-        "${get_env("TF_VAR_org_account_id")}",
-      )
-  }
+  ${local.org_auth}
   region = "us-east-1"
   default_tags {
     tags = {

--- a/infra/modules/aws/root.hcl
+++ b/infra/modules/aws/root.hcl
@@ -19,14 +19,13 @@ provider "aws" {
   }
 }
 
+# Chains off whatever the caller already is — the github-actions role in CI,
+# an SSO session locally. No static key.
 provider "aws" {
   alias = "org"
-  access_key = "${get_env("TF_VAR_org_aws_access_key_id")}"
-  secret_key = "${get_env("TF_VAR_org_aws_secret_access_key")}"
   assume_role {
-      role_arn = format("arn:aws:iam::%s:role/%s",
+      role_arn = format("arn:aws:iam::%s:role/github-actions",
         "${get_env("TF_VAR_org_account_id")}",
-        "${get_env("TF_VAR_aws_deployer_role")}",
       )
   }
   region = "us-east-1"


### PR DESCRIPTION
Drops `ORG_AWS_ACCESS_KEY_ID` / `ORG_AWS_SECRET_ACCESS_KEY` from the org provider. Those landed in plaintext in the generated `_.provider.gen.tf` on every run.

The provider now picks its auth from the environment. Locally, set `AWS_ORG_PROFILE` to an SSO profile for the org account. In CI that variable is unset, so it falls back to assuming the org `github-actions` role from the role the job already has. `route53` is the only unit using `provider = aws.org`.

Depends on [aws-org#40](https://github.com/Fomiller/aws-org/pull/40), which is applied.