### PR TITLE
fix(FOM-133): unbreak the mdbook pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'infra/**'
       - 'justfile'
       - 'just/**'
+      - 'docs/**'
    
 jobs:
   Pre-check:
@@ -38,4 +39,8 @@ jobs:
 
   Github-Pages:
     needs: Pre-check
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: fomiller/gh-actions/.github/workflows/mdbook.yaml@main

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Forrest Miller"]
 language = "en"
-multilingual = false
 src = "src"
 title = "aws-infra docs"


### PR DESCRIPTION
Three small fixes to get the docs publishing again.

- `multilingual` was dropped from mdbook's `book.toml` schema, so the build exited 101.
- The `Github-Pages` job had no `permissions` block. A reusable workflow can only narrow what the caller grants, so `deploy-pages` never got `id-token: write`.
- `docs/**` wasn't in the push path filter, so editing docs didn't trigger a publish.