### PR TITLE
chore(FOM-135): drop the dead AWSTerraform user lookups

### DIFF
--- a/.aws-assume.ini
+++ b/.aws-assume.ini
@@ -1,7 +1,0 @@
-[devTerraform]
-account = 695434033664
-role    = AWSTERRAFORM
-
-[prodTerraform]
-account = 737133467188
-role    = AWSTERRAFORM

--- a/infra/modules/aws/iam/policies/_data.tf
+++ b/infra/modules/aws/iam/policies/_data.tf
@@ -5,10 +5,6 @@ data "aws_iam_policy" "admin_access" {
   arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-data "aws_iam_user" "aws_terraform" {
-  user_name = "AWSTerraform${upper(var.environment)}"
-}
-
 data "aws_iam_policy_document" "timestream" {
   statement {
     effect = "Allow"

--- a/infra/modules/aws/iam/roles/_data.tf
+++ b/infra/modules/aws/iam/roles/_data.tf
@@ -4,7 +4,3 @@ data "aws_region" "current" {}
 data "aws_iam_policy" "admin_access" {
   arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
-
-data "aws_iam_user" "aws_terraform" {
-  user_name = "AWSTerraform${upper(var.environment)}"
-}


### PR DESCRIPTION
Removes the `aws_iam_user` data sources in `iam/roles` and `iam/policies`. Nothing referenced them, but Terraform reads every declared data source on plan, so they would start failing the moment [FOM-135](https://linear.app/fomiller/issue/FOM-135) deletes the `AWSTerraform*` users over in aws-org. This has to merge before that one.

Also drops `.aws-assume.ini`. The `AWSTERRAFORM` role it points at goes away with those users, and local auth is Identity Center now.

Planned both modules against dev with an SSO session — `No changes.` on each.