### PR TITLE
chore(FOM-140): refresh the vendored login recipe

### DIFF
--- a/just/terraform.just
+++ b/just/terraform.just
@@ -4,9 +4,9 @@ clean:
     find . -name ".terraform" -type d | xargs -r rm -rv
     find . -name ".terragrunt-cache" -type d | xargs -r rm -rv
 
-login env:
-    doppler run \
-    -- assume-role login -p {{env}}Terraform
+# One session covers all three accounts. Pick the account with AWS_PROFILE.
+login:
+    aws sso login --sso-session fomiller
 
 init dir:
     doppler run \


### PR DESCRIPTION
Picks up Fomiller/justfiles#2. `just login` now runs `aws sso login --sso-session fomiller` instead of `assume-role`, which FOM-135 broke by deleting `.aws-assume.ini`, the `AWSTERRAFORM` role, and the static key it used. [FOM-140](https://linear.app/fomiller/issue/FOM-140).

The recipe takes no argument now — one SSO session covers all three accounts and `AWS_PROFILE` picks which one you act on.

This is the whole `just fetch` output, not a hand-edit. Nothing else in the file drifted.